### PR TITLE
Fix canary CI Dockerfile path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: ./Dockerfile.Canary
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ranjithka/canary:latest


### PR DESCRIPTION
## Summary
- point the CI canary build step at ./Dockerfile.Canary
- keep the existing build context and image tag unchanged

## Why
The workflow was failing because docker/build-push-action defaulted to ./Dockerfile, but this repository only has Dockerfile.Canary and Dockerfile.Prd at the root.