### PR TITLE
Align Docker builds with Go 1.24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: ./Dockerfile.Canary
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ranjithka/canary:latest

--- a/Dockerfile.Canary
+++ b/Dockerfile.Canary
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG APP
 

--- a/Dockerfile.Prd
+++ b/Dockerfile.Prd
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /build
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.1
+toolchain go1.24.1
 
 use (
 	.


### PR DESCRIPTION
## Summary
- update Dockerfile.Canary and Dockerfile.Prd to use the Go 1.24 Alpine builder image
- update go.work to Go 1.24.0 with toolchain go1.24.1

## Why
The previous workflow fix made CI use Dockerfile.Canary correctly, which exposed the next failure: the Docker build still used Go 1.23 while the repository now requires Go 1.24 in go.mod. The workspace file also still declared Go 1.23, which caused the subsequent build step to fail.