### PR TITLE
Consolidate open PR fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main"
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   docker:
@@ -20,16 +23,17 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Login to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile.Canary
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ranjithka/canary:latest

--- a/Dockerfile.Canary
+++ b/Dockerfile.Canary
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG APP
 

--- a/Dockerfile.Prd
+++ b/Dockerfile.Prd
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /build
 

--- a/demo/services/cv/requirements.txt
+++ b/demo/services/cv/requirements.txt
@@ -3,5 +3,5 @@ opencv-python==4.8.1.78
 pillow==12.2.0
 easyocr==1.7.0
 ultralytics==8.0.206
-torch==2.1.0
+torch==2.8.0
 numpy==1.24.3

--- a/demo/services/nlp/requirements.txt
+++ b/demo/services/nlp/requirements.txt
@@ -3,4 +3,4 @@ spacy==3.7.2
 transformers==5.0.0rc3
 torch==2.8.0
 numpy==1.24.3
-scikit-learn==1.3.0
+scikit-learn==1.5.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.1
+toolchain go1.24.1
 
 use (
 	.


### PR DESCRIPTION
## Summary
- trigger the CI workflow on pull requests targeting main
- skip Docker Hub login on pull requests
- build the canary image on pull requests but only push it on main branch pushes
- align Docker builder images and go.work with Go 1.24
- bump scikit-learn to 1.5.0 in demo/services/nlp
- bump torch to 2.8.0 in demo/services/cv

## Why
This consolidates the currently open PR changes into one branch so there is a single PR to review and merge.